### PR TITLE
Throw a meaningful exception on unsupported data types in ORC

### DIFF
--- a/eel-orc/src/main/scala/io/eels/component/orc/OrcSchemaFns.scala
+++ b/eel-orc/src/main/scala/io/eels/component/orc/OrcSchemaFns.scala
@@ -30,6 +30,8 @@ object OrcSchemaFns {
         }
       case TimestampMillisType => TypeDescription.createTimestamp()
       case VarcharType(size) => TypeDescription.createVarchar().withMaxLength(size)
+      case unsupportedDataType =>
+        throw new UnsupportedOperationException(s"type ${unsupportedDataType.toString} is not supported by ORC")
     }
   }
 


### PR DESCRIPTION
I've encountered an error when moving data from a `JDBCSource` to an ORC-backed `HiveSink`.

I've manually created a Hive table to host the data contained in the original source. It may be that the semantics of `bigint` are different for Teradata (`DECIMAL(n, n)`) and Hive/ORC (`LONG`), however the problem is that whenever a `BigIntType` is encountered, a `MatchError` is thrown as this is not among the supported data types for ORC.

I solved my problem by patching the code as in this PR. It's very rough and of course I'm available to improve on this, should this be of interest for a review.

It's worth mentioning that along the way I noticed that probably the right tool to use would have been an ad-hoc implementation of `MetastoreSchemaHandler` suited for my use case. It's the first time I used Eel and unfortunately this came up later during my experimentation.

If that's the case, feel free to close this.