### PR TITLE
Fix behaviour of the OrcSource.

### DIFF
--- a/eel-orc/src/main/scala/io/eels/component/orc/OrcSource.scala
+++ b/eel-orc/src/main/scala/io/eels/component/orc/OrcSource.scala
@@ -34,7 +34,7 @@ case class OrcSource(pattern: FilePattern,
   }
 
   override def schema: StructType = {
-    val reader = OrcFile.createReader(pattern.toPaths().head, new ReaderOptions(conf).maxLength(1))
+    val reader = OrcFile.createReader(pattern.toPaths().head, new ReaderOptions(conf))
     val schema = reader.getSchema
     OrcSchemaFns.fromOrcType(schema).asInstanceOf[StructType]
   }

--- a/eel-orc/src/test/scala/io/eels/component/orc/OrcComponentTest.scala
+++ b/eel-orc/src/test/scala/io/eels/component/orc/OrcComponentTest.scala
@@ -64,6 +64,34 @@ class OrcComponentTest extends WordSpec with Matchers with BeforeAndAfter {
         Row(schema, Vector("world", "bb", 65, 1.7, true, 1950173241323L, BigDecimal(3.9), new Timestamp(1483726291000L), "qwerty", Seq("p", "q", "r"), Map("x" -> false, "y" -> true)))
       )
     }
+
+    "support reading the schema directly" in {
+      val schema = StructType(
+        Field("string", StringType),
+        Field("char", CharType(2)),
+        Field("int", IntType.Signed),
+        Field("double", DoubleType),
+        Field("boolean", BooleanType),
+        Field("long", LongType.Signed),
+        Field("decimal", DecimalType(4, 2)),
+        Field("timestamp", TimestampMillisType),
+        Field("varchar", VarcharType(100)),
+        Field("list", ArrayType(StringType)),
+        Field("map", MapType(StringType, BooleanType))
+      )
+
+      val ds = DataStream.fromRows(
+        schema,
+        Row(schema, Vector("hello", "aa", 85, 1.9, true, 3256269123123L, 9.91, 1483726491000L, "abcdef", Seq("x", "y", "z"), Map("a" -> true, "b" -> false))),
+        Row(schema, Vector("world", "bb", 65, 1.7, true, 1950173241323L, 3.9, 1483726291000L, "qwerty", Seq("p", "q", "r"), Map("x" -> false, "y" -> true)))
+      )
+
+      val path = new Path(s"test_${System.currentTimeMillis()}.orc")
+      ds.to(OrcSink(path))
+
+      OrcSource(path).schema should equal (schema)
+    }
+
     "handle null values" in {
       val schema = StructType(
         Field("a", StringType),


### PR DESCRIPTION
The `OrcSource` was complaining if read a file and requested the schema
without creating a `DataStream` (Invalid ORC-File). I've removed the
file-size limitation and added a test to verify that reading the schema
directly works as expected"