### PR TITLE
Update Publisher.scala

### DIFF
--- a/eel-core/src/main/scala/io/eels/datastream/Publisher.scala
+++ b/eel-core/src/main/scala/io/eels/datastream/Publisher.scala
@@ -80,6 +80,8 @@ object Publisher extends Logging {
           // once we've had an error that's it, we don't complete the subscriber
           if (error.get == null)
             s.completed()
+          else 
+            s.error(error.get)
         } catch {
           case t: Throwable =>
             logger.error("Error in merge subscriber", t)


### PR DESCRIPTION
Publisher.merge subscribers do not receive error notifications. This change will ensure error propagation. Currently Publisher.merge is used in DataStreamSource and SinkAction will block 999 days in  executor.awaitTermination. This change should fix this.  Note also that as is the code ignores error stored AtomicReference[Throwable].