### PR TITLE
fix : _SUCCESS is not a Parquet file (too small length: 0)

### DIFF
--- a/eel-core/src/main/scala/io/eels/component/parquet/ParquetSource.scala
+++ b/eel-core/src/main/scala/io/eels/component/parquet/ParquetSource.scala
@@ -76,7 +76,8 @@ case class ParquetSource(pattern: FilePattern,
 
   override def parts(): Seq[Publisher[Seq[Row]]] = {
     logger.debug(s"Parquet source has ${paths.size} files: ${paths.mkString(", ")}")
-    paths.map { it => new ParquetPublisher(it, predicate, projection, caseSensitive, dictionaryFiltering) }
+    paths.filter(it => !it.getName.equalsIgnoreCase(s"_SUCCESS") && !it.getName.startsWith(".")).map
+    { it => new ParquetPublisher(it, predicate, projection, caseSensitive, dictionaryFiltering) }
   }
 
   def footers(): List[Footer] = {


### PR DESCRIPTION
fix the read parquet problem when parquet file are multi partitions, the error is _SUCCESS is not a Parquet file (too small length: 0)